### PR TITLE
fix: add run() entry point so the console script can start

### DIFF
--- a/wyoming_ovos_tts/__main__.py
+++ b/wyoming_ovos_tts/__main__.py
@@ -149,6 +149,11 @@ class OVOSTTSEventHandler(AsyncEventHandler):
 
 # -----------------------------------------------------------------------------
 
+def run() -> None:
+    """Console-script entry point (see setup.py console_scripts)."""
+    asyncio.run(main())
+
+
 if __name__ == "__main__":
     try:
         asyncio.run(main())


### PR DESCRIPTION
`console_scripts` maps `wyoming-ovos-tts` → `wyoming_ovos_tts.__main__:run`, but the module only defined `async def main()` — no `run` — so the installed CLI raised `AttributeError`/`ImportError` before any arg parsing. Added a sync `run()` wrapper (`asyncio.run(main())`) matching the entry point. Found auditing for the Technical Manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)