### PR TITLE
fix: pass version to TtsVoice, matching TtsProgram

### DIFF
--- a/wyoming_ovos_tts/__main__.py
+++ b/wyoming_ovos_tts/__main__.py
@@ -85,6 +85,7 @@ async def main() -> None:
                             url="https://github.com/OpenVoiceOS/ovos-plugin-manager",
                         ),
                         installed=True,
+                        version=__version__,
                         languages=languages,
                     )
                 ],


### PR DESCRIPTION
`TtsProgram(...)` correctly passes `version=__version__`, but the nested `TtsVoice(...)` call omits it entirely.

Against `wyoming>=1.9` this crashes at startup with:

```
TypeError: TtsVoice.__init__() missing 1 required positional argument: 'version'
```

since `TtsVoice.version` became a required field in that release.

Confirmed the fix by constructing `TtsVoice` directly with and without the argument against `wyoming` 1.10.0 — fails without it, works with it. Also confirmed `wyoming-ovos-stt` and `wyoming-ovos-wakeword` don't have this bug; their equivalent `AsrModel`/`WakeModel` calls already pass `version` correctly.

Found while packaging this bridge as a Home Assistant OS Supervisor add-on: https://github.com/andlo/haos-ovos-addons